### PR TITLE
Add Nix's flake and convert setup.py to pyproject.toml

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,40 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1678901627,
+        "narHash": "sha256-U02riOqrKKzwjsxc/400XnElV+UtPUQWpANPlyazjH0=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "93a2b84fc4b70d9e089d029deacc3583435c2ed6",
+        "type": "github"
+      },
+      "original": {
+        "id": "flake-utils",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1680487167,
+        "narHash": "sha256-9FNIqrxDZgSliGGN2XJJSvcDYmQbgOANaZA4UWnTdg4=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "53dad94e874c9586e71decf82d972dfb640ef044",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,66 @@
+{
+  description = "Flake for Pure Python SHV implementation";
+
+  outputs = {
+    self,
+    flake-utils,
+    nixpkgs,
+  }:
+    with builtins;
+    with flake-utils.lib;
+    with nixpkgs.lib; let
+      pyproject = trivial.importTOML ./pyproject.toml;
+      attrList = attr: list: attrValues (getAttrs list attr);
+
+      requires = p: attrList p pyproject.project.dependencies;
+      requires-dev = p:
+        with p;
+          attrList p pyproject.project.optional-dependencies.test
+          ++ [twine];
+
+      pypkg-libshv-py = {
+        buildPythonPackage,
+        pytestCheckHook,
+      }:
+        buildPythonPackage {
+          pname = pyproject.project.name;
+          inherit (pyproject.project) version;
+          src = ./.;
+        };
+
+      pyOverlay = pyself: pysuper: {
+        libshv-py = pypkg-libshv-py;
+      };
+    in
+      {
+        overlays.default = final: prev: {
+          python3 = prev.python3.override pyOverlay;
+          python3Packages = prev.python3.pkgs;
+        };
+      }
+      // eachDefaultSystem (system: let
+        pkgs = nixpkgs.legacyPackages.${system};
+        pkgsSelf = self.packages.${system};
+        devPython = pkgs.python3.withPackages (p: (requires p) ++ (requires-dev p));
+      in {
+        packages = {
+          libshv-py = pkgs.python3Packages.callPackage pypkg-libshv-py {};
+          default = pkgsSelf.libshv-py;
+        };
+        legacyPackages = pkgs.extend self.overlays.default;
+
+        devShells = filterPackages system {
+          default = pkgs.mkShell {
+            packages = with pkgs; [
+              devPython
+              editorconfig-checker
+              gitlint
+            ];
+          };
+        };
+
+        checks.default = pkgsSelf.libshv-py;
+
+        formatter = pkgs.alejandra;
+      });
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,44 @@
+[project]
+name = "libshv-py"
+version = "0.1.0"
+description = "Pure Python SHV implementation"
+authors = [
+  { name="Elektroline a.s." },
+]
+classifiers = [
+  "Programming Language :: Python :: 3",
+  "License :: OSI Approved :: MIT License",
+  "Operating System :: OS Independent",
+]
+requires-python = ">=3.6"
+dependencies = []
+
+[project.urls]
+"Homepage" = "https://github.com/silicon-heaven/libshv-py"
+"Bug Tracker" = "https://github.com/silicon-heaven/libshv-py/issues"
+
+[project.optional-dependencies]
+test = [
+  "black",
+  "isort",
+  "mypy",
+  "pydocstyle",
+  "pylint",
+]
+
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
 [tool.isort]
 profile = 'black'
+
+[tool.pylint.format]
+recursive = "y"
+ignore = "tests"
+# C0104: prevent usage of module name in documentation (seems unreasonable)
+# W1514: requires encoding to be set for open but default is to use system's
+# encoding which is way more reasonable than introducing some assumptions.
+disable = "C0104,W1514"
+# https://black.readthedocs.io/en/stable/guides/using_black_with_other_tools.html
+max-line-length = "88"

--- a/setup.py
+++ b/setup.py
@@ -1,17 +1,5 @@
 #!/usr/bin/env python3
+"""setup.py for backward compatibility."""
 from setuptools import setup
 
-setup(
-    name="libshv-py",
-    version="0.1",
-    description="Pure Python SHV implementation",
-    url="https://github.com/silicon-heaven/libshv-py",
-    author="Elektroline a.s.",
-    author_email="software@turris.cz",
-    license="MIT",
-    packages=[
-        "chainpack",
-    ],
-    install_requires=[],
-    install_extra_requires=[],
-)
+setup()


### PR DESCRIPTION
This allows usage with Nix.

The pyproject.toml is the new way to package python projects. The migration here is due to need to read its content in Nix.