### PR TITLE
flake: fix broken overlay

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -30,13 +30,13 @@
         };
 
       pyOverlay = pyself: pysuper: {
-        libshv-py = pypkg-libshv-py;
+        libshv-py = pyself.callPackage pypkg-libshv-py {};
       };
     in
       {
         overlays.default = final: prev: {
-          python3 = prev.python3.override pyOverlay;
-          python3Packages = prev.python3.pkgs;
+          python3 = prev.python3.override {packageOverrides = pyOverlay;};
+          python3Packages = final.python3.pkgs;
         };
       }
       // eachDefaultSystem (system: let

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,9 @@ test = [
 requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
 
+[tool.setuptools.package-data]
+"*" = ["py.typed"]
+
 [tool.isort]
 profile = 'black'
 


### PR DESCRIPTION
The correct override for Python is to pass it as packageOverrides and also we have to use final packages not previous to include our package in python3Packages.